### PR TITLE
Default Ollama self-host settings

### DIFF
--- a/code/chatui/pages/converse.py
+++ b/code/chatui/pages/converse.py
@@ -333,23 +333,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_router_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_router_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_router_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -408,23 +408,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_retrieval_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_retrieval_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_retrieval_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )                                        
@@ -482,23 +482,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_generator_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_generator_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_generator_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -556,23 +556,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_hallucination_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_hallucination_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_hallucination_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -630,23 +630,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_answer_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_answer_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_answer_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                             )   

--- a/code/chatui/utils/graph.py
+++ b/code/chatui/utils/graph.py
@@ -139,8 +139,8 @@ def generate(state):
         input_variables=["question", "document"],
     )
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_generator_ip"], 
-                               port=state["nim_generator_port"] if len(state["nim_generator_port"]) > 0 else "8000",
-                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "meta/llama-3.1-8b-instruct",
+                               port=state["nim_generator_port"] if len(state["nim_generator_port"]) > 0 else "11434",
+                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "llama2:7b",
                                gpu_type=state["nim_generator_gpu_type"] if "nim_generator_gpu_type" in state else None,
                                gpu_count=state["nim_generator_gpu_count"] if "nim_generator_gpu_count" in state else None,
                                temperature=0.7) if state["generator_use_nim"] else ChatNVIDIA(model=state["generator_model_id"], temperature=0.7)
@@ -173,8 +173,8 @@ def grade_documents(state):
         input_variables=["question", "document"],
     )
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_retrieval_ip"], 
-                               port=state["nim_retrieval_port"] if len(state["nim_retrieval_port"]) > 0 else "8000",
-                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "meta/llama-3.1-8b-instruct",
+                               port=state["nim_retrieval_port"] if len(state["nim_retrieval_port"]) > 0 else "11434",
+                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "llama2:7b",
                                gpu_type=state["nim_retrieval_gpu_type"] if "nim_retrieval_gpu_type" in state else None,
                                gpu_count=state["nim_retrieval_gpu_count"] if "nim_retrieval_gpu_count" in state else None,
                                temperature=0.7) if state["retrieval_use_nim"] else ChatNVIDIA(model=state["retrieval_model_id"], temperature=0)
@@ -260,8 +260,8 @@ def route_question(state):
         input_variables=["question"],
     )
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_router_ip"], 
-                               port=state["nim_router_port"] if len(state["nim_router_port"]) > 0 else "8000",
-                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "meta/llama-3.1-8b-instruct",
+                               port=state["nim_router_port"] if len(state["nim_router_port"]) > 0 else "11434",
+                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "llama2:7b",
                                gpu_type=state["nim_router_gpu_type"] if "nim_router_gpu_type" in state else None,
                                gpu_count=state["nim_router_gpu_count"] if "nim_router_gpu_count" in state else None,
                                temperature=0.7) if state["router_use_nim"] else ChatNVIDIA(model=state["router_model_id"], temperature=0)
@@ -329,8 +329,8 @@ def grade_generation_v_documents_and_question(state):
         input_variables=["generation", "documents"],
     )
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_hallucination_ip"], 
-                               port=state["nim_hallucination_port"] if len(state["nim_hallucination_port"]) > 0 else "8000",
-                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "meta/llama-3.1-8b-instruct",
+                               port=state["nim_hallucination_port"] if len(state["nim_hallucination_port"]) > 0 else "11434",
+                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "llama2:7b",
                                gpu_type=state["nim_hallucination_gpu_type"] if "nim_hallucination_gpu_type" in state else None,
                                gpu_count=state["nim_hallucination_gpu_count"] if "nim_hallucination_gpu_count" in state else None,
                                temperature=0.7) if state["hallucination_use_nim"] else ChatNVIDIA(model=state["hallucination_model_id"], temperature=0)
@@ -347,8 +347,8 @@ def grade_generation_v_documents_and_question(state):
         input_variables=["generation", "question"],
     )
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_answer_ip"], 
-                               port=state["nim_answer_port"] if len(state["nim_answer_port"]) > 0 else "8000",
-                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "meta/llama-3.1-8b-instruct",
+                               port=state["nim_answer_port"] if len(state["nim_answer_port"]) > 0 else "11434",
+                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "llama2:7b",
                                gpu_type=state["nim_answer_gpu_type"] if "nim_answer_gpu_type" in state else None,
                                gpu_count=state["nim_answer_gpu_count"] if "nim_answer_gpu_count" in state else None,
                                temperature=0.7) if state["answer_use_nim"] else ChatNVIDIA(model=state["answer_model_id"], temperature=0)

--- a/code/chatui/utils/nim.py
+++ b/code/chatui/utils/nim.py
@@ -25,13 +25,13 @@ class CustomChatOpenAI(BaseChatModel):
     """ This is a custom built class for using LangChain to chat with custom OpenAI API-compatible endpoints, eg. NIMs. """
 
     custom_endpoint: str = Field(None, description='Endpoint of remotely running NIM')
-    port: Optional[str] = "8000"
-    model_name: Optional[str] = "meta/llama-3.1-8b-instruct"
+    port: Optional[str] = "11434"
+    model_name: Optional[str] = "llama2:7b"
     temperature: Optional[float] = 0.0
     gpu_type: Optional[str] = None
     gpu_count: Optional[str] = None
 
-    def __init__(self, custom_endpoint, port="8000", model_name="meta/llama-3.1-8b-instruct", 
+    def __init__(self, custom_endpoint, port="11434", model_name="llama2:7b",
                  gpu_type=None, gpu_count=None, temperature=0.0, **kwargs):
         super().__init__(**kwargs)
         if gpu_type and gpu_count:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,8 @@
 # Create your compose file. To learn more, please visit
 # https://docs.docker.com/reference/compose-file/
 services:
-  local-nim:
-    image: nvcr.io/nim/meta/llama-3.1-8b-instruct:latest
+  ollama:
+    image: ollama/ollama:latest
     runtime: nvidia
     deploy:
       resources:
@@ -12,14 +12,14 @@ services:
               count: 1
               capabilities: [ gpu ]
     ports:
-      - "8000:8000"
+      - "11434:11434"
     volumes:
-      - type: bind
-        source: /tmp
-        target: /opt/nim/.cache/
-    environment:
-      - NGC_API_KEY=${NVIDIA_API_KEY:?Error NVIDIA_API_KEY not set}
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
       
 networks:
   default:
     name: agentic-rag
+
+volumes:
+  ollama_data:


### PR DESCRIPTION
## Summary
- default port and model for custom chat to use local Ollama
- adjust graph helpers to expect Ollama defaults
- update UI defaults for self-hosted endpoints
- provide compose entry for Ollama container

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68793c560b44832aa939ba2c61765f8a