### PR TITLE
Default Ollama self-host settings

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -125,8 +125,6 @@ execution:
             requested: 0
         sharedMemoryMB: 1024
     secrets:
-        - variable: NVIDIA_API_KEY
-          description: NVIDIA API Key for accessing the API catalog
         - variable: TAVILY_API_KEY
           description: Tavily Search API Key
     mounts:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 - **Look and Feel**: Change the agent and UI by editing the code yourself
 
 ### Inference Your Way
-- **Free Endpoints**: use free endpoints on build.nvidia.com
-- **Self-Hosted**: Point to Ollama or NIM on your own GPUs
+- **Self-Hosted**: Uses a local Ollama container by default
 
 ## Get Started 
 
@@ -26,15 +25,14 @@
 > You can run Agentic RAG without Workbench, but this README requires [NVIDIA AI Workbench](https://www.nvidia.com/en-us/deep-learning-ai/solutions/data-science/workbench/) installed.
 > See [how to install it here](https://docs.nvidia.com/ai-workbench/user-guide/latest/installation/overview.html).
 
-> You need internet because Agentic RAG uses an NVIDIA endpoint for document embedding.
+> You need internet because Agentic RAG relies on Tavily for web search results.
 
 ### Easy Mode (< 5 minutes if Workbench installed)
-1. Get NVIDIA and Tavily API keys:  
-   - ``NVIDIA_API_KEY`` → [Generate](https://org.ngc.nvidia.com/setup/api-keys)  See instructions [here](https://docs.nvidia.com/ai-enterprise/deployment/spark-rapids-accelerator/latest/appendix-ngc.html).
-   - ``TAVILY_API_KEY`` → [Generate](https://tavily.com)  
+1. Get a Tavily API key:
+   - ``TAVILY_API_KEY`` → [Generate](https://tavily.com)
 2. **Clone** this repo with AI Workbench > [configure the keys](https://docs.nvidia.com/ai-workbench/user-guide/latest/environment/variables.html#basic-usage-for-environment-variables) when prompted.  
 3. Click **Open Chat** > Go to the **Document** tab in the web app > Click **Add to Context**.  
-4. Type in your question > Hit enter - answers come from free cloud endpoints.
+4. Type in your question > Hit enter - answers come from your local Ollama model.
 
 ## Details for the README Modes
 <details>
@@ -49,7 +47,7 @@
 |------|--------------------|-------------|
 | 1. Open the Desktop App > Select [local](https://docs.nvidia.com/ai-workbench/user-guide/latest/locations/locations.html). | Probably a  Docker Desktop issue (if selected on install). **Fix**:  See [troubleshooting here](https://docs.nvidia.com/ai-workbench/user-guide/latest/troubleshooting/troubleshooting.html) | <p align="center"><img src="./data/readme-images/desktop-icon.png" width="120" alt="Desktop App Icon"></p> |
 | 2. Click **Clone Project** > Paste repository [URL](https://github.com/NVIDIA/workbench-example-agentic-rag) > **Clone** | Incorrect URL. **Fix**: use the correct URL. | <img src="./data/readme-images/clone-button.png" width="250" height="auto" alt="Clone Button"> |
-| 3. Click **Resolve Now** > Enter NVIDIA and Tavily API keys. | You don't see the banner. **Fix**: go to **Project Container > Variables > Configure** for API keys. See [docs here](https://docs.nvidia.com/ai-workbench/user-guide/latest/environment/variables.html) | <img src="./data/readme-images/resolve-now.png" width="200" height="auto" alt="Resolve Now Warning"> |
+| 3. Click **Resolve Now** > Enter your Tavily API key. | You don't see the banner. **Fix**: go to **Project Container > Variables > Configure** for API keys. See [docs here](https://docs.nvidia.com/ai-workbench/user-guide/latest/environment/variables.html) | <img src="./data/readme-images/resolve-now.png" width="200" height="auto" alt="Resolve Now Warning"> |
 | 4. Click **Open Chat**. | Very little can go wrong here | <img src="./data/readme-images/open-chat-screen-shot.png" width="250" height="auto" alt="Open Chat Button"> |
 | 5. Click **Documents > Create Context**. | Incorrect API key. Fix per Step 3 above. | <img src="./data/readme-images/add-to-context-button.png" width="300" height="auto" alt="Add to Context Button"> |
 | 6. Type question > Hit  enter. |  Incorrect API key. Fix per Step 3 above. | <img src="./data/readme-images/hit-enter.png" width="200" height="auto" alt="Chat Text"> |

--- a/code/chatui/pages/converse.py
+++ b/code/chatui/pages/converse.py
@@ -168,11 +168,11 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
 
         """ Keep state of which queries need to use NIMs vs API Endpoints. """
         
-        router_use_nim = gr.State(False)
-        retrieval_use_nim = gr.State(False)
-        generator_use_nim = gr.State(False)
-        hallucination_use_nim = gr.State(False)
-        answer_use_nim = gr.State(False)
+        router_use_nim = gr.State(True)
+        retrieval_use_nim = gr.State(True)
+        generator_use_nim = gr.State(True)
+        hallucination_use_nim = gr.State(True)
+        answer_use_nim = gr.State(True)
 
         """ Build the Chat Application. """
         
@@ -231,7 +231,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                 """
                                 ### Purpose: Generate and evaluate a generic response&nbsp;<ins>without</ins>&nbsp;RAG
 
-                                * Ensure both ``NVIDIA_API_KEY`` and ``TAVILY_API_KEY`` are configured in AI Workbench.
+                                * Ensure ``TAVILY_API_KEY`` is configured in AI Workbench.
                                 * Select a sample query from the chatbot on the left-hand side of the window.
                                 * Wait for the response to generate and evaluate the relevance of the response.
                                 """,
@@ -304,9 +304,9 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                             ########################
                             router_btn = gr.Button("Router", variant="sm")
                             with gr.Group(visible=False) as group_router:
-                                with gr.Tabs(selected=0) as router_tabs:
+                                with gr.Tabs(selected=1) as router_tabs:
                                     with gr.TabItem("API Endpoints", id=0) as router_api:
-                                        router_mode_banner = gr.Markdown(value="💻 **Using API Endpoint**", elem_classes=["mode-banner"])
+                                        router_mode_banner = gr.Markdown(value="🛠️ **Using Self-Hosted Endpoint**", elem_classes=["mode-banner"])
                                         model_router = gr.Dropdown(model_list, 
                                                                 value=model_list[0],
                                                                 label="Select a Model",
@@ -333,23 +333,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_router_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_router_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_router_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -379,8 +379,8 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                             ##################################
                             retrieval_btn = gr.Button("Retrieval Grader", variant="sm")
                             with gr.Group(visible=False) as group_retrieval:
-                                with gr.Tabs(selected=0) as retrieval_tabs:
-                                    retrieval_mode_banner = gr.Markdown(value="💻 **Using API Endpoint**", elem_classes=["mode-banner"])
+                                with gr.Tabs(selected=1) as retrieval_tabs:
+                                    retrieval_mode_banner = gr.Markdown(value="🛠️ **Using Self-Hosted Endpoint**", elem_classes=["mode-banner"])
 
                                     with gr.TabItem("API Endpoints", id=0) as retrieval_api:
                                         model_retrieval = gr.Dropdown(model_list, 
@@ -408,23 +408,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_retrieval_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_retrieval_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_retrieval_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )                                        
@@ -454,8 +454,8 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                             ###########################
                             generator_btn = gr.Button("Generator", variant="sm")
                             with gr.Group(visible=False) as group_generator:
-                                with gr.Tabs(selected=0) as generator_tabs:
-                                    generator_mode_banner = gr.Markdown(value="💻 **Using API Endpoint**", elem_classes=["mode-banner"])
+                                with gr.Tabs(selected=1) as generator_tabs:
+                                    generator_mode_banner = gr.Markdown(value="🛠️ **Using Self-Hosted Endpoint**", elem_classes=["mode-banner"])
                                     with gr.TabItem("API Endpoints", id=0) as generator_api:
                                         model_generator = gr.Dropdown(model_list, 
                                                                     value=model_list[0],
@@ -482,23 +482,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_generator_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_generator_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_generator_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -528,8 +528,8 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                             ######################################
                             hallucination_btn = gr.Button("Hallucination Grader", variant="sm")
                             with gr.Group(visible=False) as group_hallucination:
-                                with gr.Tabs(selected=0) as hallucination_tabs:
-                                    hallucination_mode_banner = gr.Markdown(value="💻 **Using API Endpoint**", elem_classes=["mode-banner"])
+                                with gr.Tabs(selected=1) as hallucination_tabs:
+                                    hallucination_mode_banner = gr.Markdown(value="🛠️ **Using Self-Hosted Endpoint**", elem_classes=["mode-banner"])
                                     with gr.TabItem("API Endpoints", id=0) as hallucination_api:
                                         model_hallucination = gr.Dropdown(model_list, 
                                                                                 value=model_list[0],
@@ -556,23 +556,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_hallucination_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_hallucination_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_hallucination_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                         )
@@ -602,8 +602,8 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                             ###############################
                             answer_btn = gr.Button("Answer Grader", variant="sm")
                             with gr.Group(visible=False) as group_answer:
-                                with gr.Tabs(selected=0) as answer_tabs:
-                                    answer_mode_banner = gr.Markdown(value="💻 **Using API Endpoint**", elem_classes=["mode-banner"])
+                                with gr.Tabs(selected=1) as answer_tabs:
+                                    answer_mode_banner = gr.Markdown(value="🛠️ **Using Self-Hosted Endpoint**", elem_classes=["mode-banner"])
                                     with gr.TabItem("API Endpoints", id=0) as answer_api:
                                         model_answer = gr.Dropdown(model_list, 
                                                                         value=model_list[0],
@@ -630,23 +630,23 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         
                                         with gr.Row():
                                             nim_answer_ip = gr.Textbox(
-                                                value = "agentic-rag-local-nim-1",
+                                                value = "ollama",
                                                 label=HOST_NAME,
                                                 info="Local microservice OR IP address running a remote microservice",
                                                 elem_id="rag-inputs",
                                                 scale=2
                                             )
                                             nim_answer_port = gr.Textbox(
-                                                placeholder="8000",
+                                                placeholder="11434",
                                                 label=HOST_PORT,
-                                                info="Optional, (default: 8000)",
+                                                info="Optional, (default: 11434)",
                                                 elem_id="rag-inputs",
                                                 scale=1
                                             )
                                         nim_answer_id = gr.Textbox(
-                                            placeholder = "meta/llama-3.1-8b-instruct",
+                                            placeholder = "llama2:7b",
                                             label=HOST_MODEL,
-                                            info="If none specified, defaults to: meta/llama-3.1-8b-instruct",
+                                            info="If none specified, defaults to: llama2:7b",
                                             elem_id="rag-inputs",
                                             interactive=True
                                             )   

--- a/code/chatui/utils/database.py
+++ b/code/chatui/utils/database.py
@@ -21,7 +21,7 @@ from langchain_community.document_loaders import (
     CSVLoader 
 )
 from langchain_community.vectorstores import Chroma
-from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
+from langchain_community.embeddings import OllamaEmbeddings
 
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urlparse
@@ -31,12 +31,8 @@ import mimetypes
 
 
 
-# Handling which API to use based on public vs NVIDIA internal
-# Check if the INTERNAL_API environment variable is set to yes. Don't set if not NVIDIA employee, as you can't access them.
-INTERNAL_API = os.getenv('INTERNAL_API', 'no')
-
-# Default model for public embedding
-EMBEDDINGS_MODEL = 'NV-Embed-QA'
+# Default model for local embeddings
+EMBEDDINGS_MODEL = 'llama2'
 
 # Set the chunk size and overlap for the text splitter. Uses defaults but allows them to be set as environment variables.
 DEFAULT_CHUNK_SIZE = 250
@@ -46,15 +42,6 @@ CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", DEFAULT_CHUNK_SIZE))
 CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", DEFAULT_CHUNK_OVERLAP))
 
 
-if INTERNAL_API == 'yes':
-    # NVIDIA employees can use internal endpoints
-    EMBEDDINGS_MODEL = 'nvdev/nvidia/nv-embedqa-e5-v5'
-    print("[config] INTERNAL_API detected.")
-    print(f"[config] Using internal embedding model: {EMBEDDINGS_MODEL}")
-
-else:
-    print("[config] No INTERNAL_API set.")
-    print(f"[config] Using public embedding model: {EMBEDDINGS_MODEL}")
 
 
 # Adding nltk data
@@ -124,7 +111,7 @@ def upload(urls: List[str]):
         vectorstore = Chroma.from_documents(
             documents=doc_splits,
             collection_name="rag-chroma",
-            embedding=NVIDIAEmbeddings(model=EMBEDDINGS_MODEL),
+            embedding=OllamaEmbeddings(model=EMBEDDINGS_MODEL),
             persist_directory="/project/data",
         )
         return vectorstore
@@ -183,7 +170,7 @@ def embed_documents(doc_splits: List[Any]):
         vectorstore = Chroma.from_documents(
             documents=doc_splits,
             collection_name="rag-chroma",
-            embedding=NVIDIAEmbeddings(model=EMBEDDINGS_MODEL),
+            embedding=OllamaEmbeddings(model=EMBEDDINGS_MODEL),
             persist_directory="/project/data",
         )
         return vectorstore
@@ -229,7 +216,7 @@ def _clear(
         # Clear the collection via Chroma client
         vectorstore = Chroma(
             collection_name=collection_name,
-            embedding_function=NVIDIAEmbeddings(model=EMBEDDINGS_MODEL),
+            embedding_function=OllamaEmbeddings(model=EMBEDDINGS_MODEL),
             persist_directory=persist_directory,
         )
         vectorstore._client.delete_collection(name=collection_name)
@@ -261,7 +248,7 @@ def _clear(
 #     """ This is a helper function for emptying the collection the vector store. """
 #     vectorstore = Chroma(
 #         collection_name="rag-chroma",
-#         embedding_function=NVIDIAEmbeddings(model=EMBEDDINGS_MODEL),
+#         embedding_function=OllamaEmbeddings(model=EMBEDDINGS_MODEL),
 #         persist_directory="/project/data",
 #     )
     
@@ -272,7 +259,7 @@ def get_retriever():
     """ This is a helper function for returning the retriever object of the vector store. """
     vectorstore = Chroma(
         collection_name="rag-chroma",
-        embedding_function=NVIDIAEmbeddings(model=EMBEDDINGS_MODEL),
+        embedding_function=OllamaEmbeddings(model=EMBEDDINGS_MODEL),
         persist_directory="/project/data",
     )
     retriever = vectorstore.as_retriever()

--- a/code/chatui/utils/graph.py
+++ b/code/chatui/utils/graph.py
@@ -20,7 +20,6 @@ from typing import List, Optional
 
 from langchain.prompts import PromptTemplate
 from langchain_core.output_parsers import StrOutputParser, JsonOutputParser
-from langchain_nvidia_ai_endpoints import ChatNVIDIA
 from langchain_community.tools.tavily_search import TavilySearchResults
 
 from chatui.utils import database, nim
@@ -138,12 +137,12 @@ def generate(state):
         template=state["prompt_generator"],
         input_variables=["question", "document"],
     )
-    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_generator_ip"], 
-                               port=state["nim_generator_port"] if len(state["nim_generator_port"]) > 0 else "8000",
-                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "meta/llama-3.1-8b-instruct",
-                               gpu_type=state["nim_generator_gpu_type"] if "nim_generator_gpu_type" in state else None,
-                               gpu_count=state["nim_generator_gpu_count"] if "nim_generator_gpu_count" in state else None,
-                               temperature=0.7) if state["generator_use_nim"] else ChatNVIDIA(model=state["generator_model_id"], temperature=0.7)
+    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_generator_ip"],
+                               port=state["nim_generator_port"] if len(state["nim_generator_port"]) > 0 else "11434",
+                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "llama2:7b",
+                               gpu_type=state.get("nim_generator_gpu_type"),
+                               gpu_count=state.get("nim_generator_gpu_count"),
+                               temperature=0.7)
     rag_chain = prompt | llm | StrOutputParser()
     generation = rag_chain.invoke({"context": documents, "question": question})
     return {"documents": documents, "question": question, "generation": generation}
@@ -172,12 +171,12 @@ def grade_documents(state):
         template=state["prompt_retrieval"],
         input_variables=["question", "document"],
     )
-    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_retrieval_ip"], 
-                               port=state["nim_retrieval_port"] if len(state["nim_retrieval_port"]) > 0 else "8000",
-                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "meta/llama-3.1-8b-instruct",
-                               gpu_type=state["nim_retrieval_gpu_type"] if "nim_retrieval_gpu_type" in state else None,
-                               gpu_count=state["nim_retrieval_gpu_count"] if "nim_retrieval_gpu_count" in state else None,
-                               temperature=0.7) if state["retrieval_use_nim"] else ChatNVIDIA(model=state["retrieval_model_id"], temperature=0)
+    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_retrieval_ip"],
+                               port=state["nim_retrieval_port"] if len(state["nim_retrieval_port"]) > 0 else "11434",
+                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "llama2:7b",
+                               gpu_type=state.get("nim_retrieval_gpu_type"),
+                               gpu_count=state.get("nim_retrieval_gpu_count"),
+                               temperature=0.7)
     retrieval_grader = prompt | llm | JsonOutputParser()
     for d in documents:
         score = retrieval_grader.invoke(
@@ -259,12 +258,12 @@ def route_question(state):
         template=state["prompt_router"],
         input_variables=["question"],
     )
-    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_router_ip"], 
-                               port=state["nim_router_port"] if len(state["nim_router_port"]) > 0 else "8000",
-                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "meta/llama-3.1-8b-instruct",
-                               gpu_type=state["nim_router_gpu_type"] if "nim_router_gpu_type" in state else None,
-                               gpu_count=state["nim_router_gpu_count"] if "nim_router_gpu_count" in state else None,
-                               temperature=0.7) if state["router_use_nim"] else ChatNVIDIA(model=state["router_model_id"], temperature=0)
+    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_router_ip"],
+                               port=state["nim_router_port"] if len(state["nim_router_port"]) > 0 else "11434",
+                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "llama2:7b",
+                               gpu_type=state.get("nim_router_gpu_type"),
+                               gpu_count=state.get("nim_router_gpu_count"),
+                               temperature=0.7)
     question_router = prompt | llm | JsonOutputParser()
     source = question_router.invoke({"question": question})
     print(source)
@@ -328,12 +327,12 @@ def grade_generation_v_documents_and_question(state):
         template=state["prompt_hallucination"],
         input_variables=["generation", "documents"],
     )
-    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_hallucination_ip"], 
-                               port=state["nim_hallucination_port"] if len(state["nim_hallucination_port"]) > 0 else "8000",
-                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "meta/llama-3.1-8b-instruct",
-                               gpu_type=state["nim_hallucination_gpu_type"] if "nim_hallucination_gpu_type" in state else None,
-                               gpu_count=state["nim_hallucination_gpu_count"] if "nim_hallucination_gpu_count" in state else None,
-                               temperature=0.7) if state["hallucination_use_nim"] else ChatNVIDIA(model=state["hallucination_model_id"], temperature=0)
+    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_hallucination_ip"],
+                               port=state["nim_hallucination_port"] if len(state["nim_hallucination_port"]) > 0 else "11434",
+                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "llama2:7b",
+                               gpu_type=state.get("nim_hallucination_gpu_type"),
+                               gpu_count=state.get("nim_hallucination_gpu_count"),
+                               temperature=0.7)
     hallucination_grader = prompt | llm | JsonOutputParser()
 
     score = hallucination_grader.invoke(
@@ -346,12 +345,12 @@ def grade_generation_v_documents_and_question(state):
         template=state["prompt_answer"],
         input_variables=["generation", "question"],
     )
-    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_answer_ip"], 
-                               port=state["nim_answer_port"] if len(state["nim_answer_port"]) > 0 else "8000",
-                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "meta/llama-3.1-8b-instruct",
-                               gpu_type=state["nim_answer_gpu_type"] if "nim_answer_gpu_type" in state else None,
-                               gpu_count=state["nim_answer_gpu_count"] if "nim_answer_gpu_count" in state else None,
-                               temperature=0.7) if state["answer_use_nim"] else ChatNVIDIA(model=state["answer_model_id"], temperature=0)
+    llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_answer_ip"],
+                               port=state["nim_answer_port"] if len(state["nim_answer_port"]) > 0 else "11434",
+                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "llama2:7b",
+                               gpu_type=state.get("nim_answer_gpu_type"),
+                               gpu_count=state.get("nim_answer_gpu_count"),
+                               temperature=0.7)
     answer_grader = prompt | llm | JsonOutputParser()
     
     if grade == "yes":

--- a/code/chatui/utils/nim.py
+++ b/code/chatui/utils/nim.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from langchain_openai import ChatOpenAI
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.load.dump import dumps
 from pydantic import Field
@@ -25,13 +24,13 @@ class CustomChatOpenAI(BaseChatModel):
     """ This is a custom built class for using LangChain to chat with custom OpenAI API-compatible endpoints, eg. NIMs. """
 
     custom_endpoint: str = Field(None, description='Endpoint of remotely running NIM')
-    port: Optional[str] = "8000"
-    model_name: Optional[str] = "meta/llama-3.1-8b-instruct"
+    port: Optional[str] = "11434"
+    model_name: Optional[str] = "llama2:7b"
     temperature: Optional[float] = 0.0
     gpu_type: Optional[str] = None
     gpu_count: Optional[str] = None
 
-    def __init__(self, custom_endpoint, port="8000", model_name="meta/llama-3.1-8b-instruct", 
+    def __init__(self, custom_endpoint, port="11434", model_name="llama2:7b",
                  gpu_type=None, gpu_count=None, temperature=0.0, **kwargs):
         super().__init__(**kwargs)
         if gpu_type and gpu_count:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,8 @@
 # Create your compose file. To learn more, please visit
 # https://docs.docker.com/reference/compose-file/
 services:
-  local-nim:
-    image: nvcr.io/nim/meta/llama-3.1-8b-instruct:latest
+  ollama:
+    image: ollama/ollama:latest
     runtime: nvidia
     deploy:
       resources:
@@ -12,14 +12,14 @@ services:
               count: 1
               capabilities: [ gpu ]
     ports:
-      - "8000:8000"
+      - "11434:11434"
     volumes:
-      - type: bind
-        source: /tmp
-        target: /opt/nim/.cache/
-    environment:
-      - NGC_API_KEY=${NVIDIA_API_KEY:?Error NVIDIA_API_KEY not set}
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
       
 networks:
   default:
     name: agentic-rag
+
+volumes:
+  ollama_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jupyterlab>3.0
-langchain-nvidia-ai-endpoints==0.3.7
 langchain-chroma==0.2.0
 langchain-community==0.3.15
 langchain-openai==0.3.2


### PR DESCRIPTION
## Summary
- default port and model for custom chat to use local Ollama
- adjust graph helpers to assume self-hosted endpoint
- update UI defaults for self-hosted tabs and banner text
- clarify README that Tavily is the only remote service

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68793c560b44832aa939ba2c61765f8a