### PR TITLE
Fix deprecated imports

### DIFF
--- a/code/chatui/utils/database.py
+++ b/code/chatui/utils/database.py
@@ -20,8 +20,8 @@ from langchain_community.document_loaders import (
     TextLoader,
     CSVLoader 
 )
-from langchain_community.vectorstores import Chroma
-from langchain_community.embeddings import OllamaEmbeddings
+from langchain_chroma import Chroma
+from langchain_ollama import OllamaEmbeddings
 
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urlparse

--- a/code/langgraph_rag_agent_llama3_nvidia_nim.ipynb
+++ b/code/langgraph_rag_agent_llama3_nvidia_nim.ipynb
@@ -133,7 +133,7 @@
     "\n",
     "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
     "from langchain_community.document_loaders import WebBaseLoader\n",
-    "from langchain_community.vectorstores import Chroma\n",
+    "from langchain_chroma import Chroma\n",
     "from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings\n",
     "\n",
     "urls = [\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tesseract==0.1.3
 nltk==3.8.1
 fastapi==0.111.0
 requests
+langchain-ollama==0.3.5


### PR DESCRIPTION
## Summary
- update imports for Chroma and OllamaEmbeddings
- add langchain-ollama dependency
- update notebook example

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687a6ef684cc832a9707434501e67a99