### PR TITLE
Fix placeholder braces in prompts

### DIFF
--- a/code/chatui/prompts/prompts_llama3.py
+++ b/code/chatui/prompts/prompts_llama3.py
@@ -18,7 +18,7 @@
 router_prompt = """
 <|begin_of_text|><|start_header_id|>system<|end_header_id|> 
 You are an expert at routing a user question to a vectorstore or web search. Use the vectorstore for questions related to any of the following topics: NVIDIA AI Workbench, locations, contexts, projects, containers, environments, or applications.  You do not need to be stringent with the keywords in the question related to these topics. Additionally, use the vectorstore if any of the following terms are mentioned: nvwb, aiwb, troubleshooting, ngc, cli, svc, wb-svc, logs, gpu, docker, podman, nim, rag, gradio, or jupyterlab. Otherwise, use web-search. Give a binary choice 'web_search' or 'vectorstore' based on the question. Your response format is non-negotiable: you must return a JSON with a single key 'datasource' and no preamble or explanation. 
-Return only one of the following JSON objects: {"datasource": "web_search"} or {"datasource": "vectorstore"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"datasource": "web_search"}} or {{"datasource": "vectorstore"}}. Do not include any extra text.
 
 Question to route: {question} 
 
@@ -30,7 +30,7 @@ retrieval_prompt = """
 You are a grader assessing relevance of a retrieved document to a user question. If the document contains keywords related to the user question, grade it as relevant. It does not need to be a stringent test. The goal is to filter out erroneous retrievals. \n
 Give a binary score 'yes' or 'no' score to indicate whether the document is relevant to the question. \n
 Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no premable or explanation.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 <|eot_id|><|start_header_id|>user<|end_header_id|>
 Here is the retrieved document: \n {document} \n
@@ -56,7 +56,7 @@ Answer:
 hallucination_prompt = """
 <|begin_of_text|><|start_header_id|>system<|end_header_id|> 
 You are a grader assessing whether an answer is grounded in and supported by a set of facts. Give a binary 'yes' or 'no' score to indicate whether the answer is grounded in and supported by a set of facts. Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no preamble or explanation. 
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 <|eot_id|><|start_header_id|>user<|end_header_id|>
 Here are the facts:
@@ -69,7 +69,7 @@ Here is the answer: {generation}
 answer_prompt = """
 <|begin_of_text|><|start_header_id|>system<|end_header_id|> 
 You are a grader assessing whether an answer is useful to resolve a question. Give a binary score 'yes' or 'no' to indicate whether the answer is useful to resolve a question. Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no preamble or explanation.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 <|eot_id|><|start_header_id|>user<|end_header_id|> 
 Here is the answer:

--- a/code/chatui/prompts/prompts_mistral.py
+++ b/code/chatui/prompts/prompts_mistral.py
@@ -17,7 +17,7 @@
 
 router_prompt = """
 <s>[INST] You are an expert at routing a user question to a vectorstore or web search. Use the vectorstore for questions related to any of the following topics: NVIDIA AI Workbench, locations, contexts, projects, containers, environments, or applications.  You do not need to be stringent with the keywords in the question related to these topics. Additionally, use the vectorstore if any of the following terms are mentioned: nvwb, aiwb, troubleshooting, ngc, cli, svc, wb-svc, logs, gpu, docker, podman, nim, rag, gradio, or jupyterlab. Otherwise, use web-search. Give a binary choice 'web_search' or 'vectorstore' based on the question. Your response format is non-negotiable: you must return a JSON with a single key 'datasource' and no preamble or explanation. 
-Return only one of the following JSON objects: {"datasource": "web_search"} or {"datasource": "vectorstore"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"datasource": "web_search"}} or {{"datasource": "vectorstore"}}. Do not include any extra text.
 
 Question to route: {question} [/INST]
 """
@@ -26,7 +26,7 @@ retrieval_prompt = """
 <s>[INST] You are a grader assessing relevance of a retrieved document to a user question. If the document contains keywords related to the user question, grade it as relevant. It does not need to be a stringent test. The goal is to filter out erroneous retrievals. \n
 Give a binary score 'yes' or 'no' score to indicate whether the document is relevant to the question. \n
 Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no premable or explanation.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 Here is the retrieved document: \n {document} \n
 Here is the user question: {question} 
@@ -45,7 +45,7 @@ Answer: [/INST]
 
 hallucination_prompt = """
 <s>[INST] You are a grader assessing whether an answer is grounded in and supported by a set of facts. Give a binary 'yes' or 'no' score to indicate whether the answer is grounded in and supported by a set of facts. Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no preamble or explanation. 
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 Here are the facts:
 \n ------- \n {documents} \n ------- \n
@@ -56,7 +56,7 @@ Here is the answer: {generation}
 
 answer_prompt = """
 <s>[INST] You are a grader assessing whether an answer is useful to resolve a question. Give a binary score 'yes' or 'no' to indicate whether the answer is useful to resolve a question. Your response format is non-negotiable: you must provide the binary score as a JSON with a single key 'score' and no preamble or explanation.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 Here is the answer:
 \n ------- \n {generation} \n ------- \n


### PR DESCRIPTION
## Summary
- escape literal braces in prompts to avoid missing variable errors

## Testing
- `python -m py_compile code/chatui/prompts/prompts_llama3.py code/chatui/prompts/prompts_mistral.py`

------
https://chatgpt.com/codex/tasks/task_e_687a97734ff8832a8d3138ca870e1f58