### PR TITLE
Resolve Milvus etcd connection issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Use these details if you want to modify the application, e.g. by configuring pro
 3. Start the Milvus container from `compose.yaml` using Docker Compose.
    - The compose file configures Milvus to run in standalone mode with GPU support.
    - The `milvus` service is multi-arch and works on arm64 systems including NVIDIA Blackwell.
+   - If you run Milvus with an **external etcd** instance, set the `ETCD_ENDPOINTS` environment variable to the host's IP address. Using `localhost` will fail inside the container.
 4. Configure the chat app to use the self-hosted endpoint.
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,11 @@ services:
     command: ["milvus", "run", "standalone"]
     runtime: nvidia
     platform: linux/arm64
+    environment:
+      # Use an external etcd instance by providing its endpoint. Do not use
+      # localhost here because it resolves inside the container.  If this
+      # variable is empty, Milvus defaults to its embedded etcd.
+      ETCD_ENDPOINTS: ${ETCD_ENDPOINTS:-}
     ports:
       - "19530:19530"
       - "9091:9091"

--- a/variables.env
+++ b/variables.env
@@ -7,3 +7,7 @@ TENSORBOARD_LOGS_DIRECTORY=/data/tensorboard/logs/
 INTERNAL_API=no
 # Base URL for the Ollama service used for embeddings and local inference
 OLLAMA_BASE_URL=http://ollama:11434
+# Endpoint for an external etcd instance used by Milvus.
+# Example: ETCD_ENDPOINTS=http://host.docker.internal:2379
+# Leave empty to use Milvus's embedded etcd.
+#ETCD_ENDPOINTS=


### PR DESCRIPTION
## Summary
- allow Milvus container to point at an external etcd instance
- document ETCD_ENDPOINTS in the README
- add example to `variables.env`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687ab2477708832aadeeb147e279881e