### PR TITLE
Resolve Milvus etcd connection issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Use these details if you want to modify the application, e.g. by configuring pro
 3. Start the Milvus container from `compose.yaml` using Docker Compose.
    - The compose file configures Milvus to run in standalone mode with GPU support.
    - The `milvus` service is multi-arch and works on arm64 systems including NVIDIA Blackwell.
+   - Milvus uses an **internal etcd** service at `http://etcd:2379` by default. Set `ETCD_ENDPOINTS` if you want to connect to a different etcd instance.
 4. Configure the chat app to use the self-hosted endpoint.
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,11 +16,26 @@ services:
     volumes:
       - ollama_data:/root/.ollama
     restart: unless-stopped
+  etcd:
+    image: bitnami/etcd:3.5
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+    ports:
+      - "2379:2379"
+    volumes:
+      - etcd_data:/etcd
+    restart: unless-stopped
   milvus:
     image: milvusdb/milvus:latest
     command: ["milvus", "run", "standalone"]
     runtime: nvidia
     platform: linux/arm64
+    environment:
+      # Milvus connects to the internal etcd service by default.
+      # Override ETCD_ENDPOINTS if you want to use a different instance.
+      ETCD_ENDPOINTS: ${ETCD_ENDPOINTS:-http://etcd:2379}
     ports:
       - "19530:19530"
       - "9091:9091"
@@ -35,3 +50,4 @@ networks:
 volumes:
   ollama_data:
   milvus_data:
+  etcd_data:

--- a/variables.env
+++ b/variables.env
@@ -7,3 +7,7 @@ TENSORBOARD_LOGS_DIRECTORY=/data/tensorboard/logs/
 INTERNAL_API=no
 # Base URL for the Ollama service used for embeddings and local inference
 OLLAMA_BASE_URL=http://ollama:11434
+# Endpoint for the etcd service used by Milvus.
+# Default points to the internal container started in `compose.yaml`.
+# Example to override: ETCD_ENDPOINTS=http://my-etcd:2379
+#ETCD_ENDPOINTS=http://etcd:2379


### PR DESCRIPTION
## Summary
- allow Milvus container to point at an internal etcd instance
- document internal ETCD_ENDPOINTS in the README
- default ETCD_ENDPOINTS in `variables.env`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687ab2477708832aadeeb147e279881e