### PR TITLE
Use compose network Milvus host by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Use these details if you want to modify the application, e.g. by configuring pro
    - If Milvus fails to start or connect, see [Milvus Troubleshooting](agentic-rag-docs/milvus-troubleshooting.md).
 
 4. Configure the chat app to use the self-hosted endpoint.
+   - The app automatically connects to the `milvus` service defined in `compose.yaml`.
+     Set `MILVUS_HOST` only if your vector database runs elsewhere.
 
 
 

--- a/code/chatui/utils/database.py
+++ b/code/chatui/utils/database.py
@@ -36,7 +36,10 @@ EMBEDDINGS_MODEL = 'llama3:8b-instruct'
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
 
 # Milvus connection configuration
-MILVUS_HOST = os.getenv("MILVUS_HOST", "localhost")  # Use service name from compose.yaml
+# Default to the `milvus` service name from the compose network so the
+# application works out of the box when all services are containerized.
+# Override with the MILVUS_HOST variable if connecting to a different host.
+MILVUS_HOST = os.getenv("MILVUS_HOST", "milvus")
 MILVUS_PORT = os.getenv("MILVUS_PORT", "19530")
 
 # Custom Milvus connection args

--- a/variables.env
+++ b/variables.env
@@ -24,4 +24,10 @@ DEFAULT_ANSWER_MODEL=llama3-chatqa:8b
 
 # Address of the MinIO service used by Milvus
 # Example to override: MINIO_ADDRESS=http://my-minio:9000
+
+# Hostname of the Milvus service used by the app. Defaults to `milvus` so the
+# project works out of the box with the compose stack. Override this variable if
+# you run Milvus elsewhere.
+#MILVUS_HOST=milvus
+
 #MINIO_ADDRESS=http://minio:9000


### PR DESCRIPTION
## Summary
- default to the milvus service when connecting to Milvus
- clarify host configuration in variables.env
- document that MILVUS_HOST only needed when overriding the compose service

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user during downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68825c9c1ef4832aadafd56c7e9a3c24