### PR TITLE
Set llama3-chatqa as default LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Use these details if you want to modify the application, e.g. by configuring pro
 
 1. Set up a Linux box with an NVIDIA GPU and Docker.
 2. Deploy an Ollama container or an NVIDIA NIM on that host.
-   - The compose file automatically pulls the model specified by `OLLAMA_MODEL` in `variables.env` when the Ollama container starts. Change this value to use a different LLM.
+   - The compose file automatically pulls the model specified by `OLLAMA_MODEL` in `variables.env` when the Ollama container starts. The default is `llama3-chatqa:8b`.
+   - Change this value if you prefer a different LLM.
 3. Documents are embedded into a local Chroma vector database stored under `data/`.
    No additional vector database services are required.
 

--- a/agentic-rag-docs/self-host.md
+++ b/agentic-rag-docs/self-host.md
@@ -70,7 +70,7 @@ docker run -d --name ollama \
   --gpus all --restart unless-stopped \
   -p <remote-port>:11434 \
   -v ollama_data:/root/.ollama \
-  -e OLLAMA_MODEL=llama3:8b-instruct \
+  -e OLLAMA_MODEL=llama3-chatqa:8b \
   ollama/ollama:latest
 
 # Make sure it is running properly
@@ -98,7 +98,7 @@ You will need the remote ip, ``<remote-ip>``, and the remote port, ``<remote-por
 
 curl -X POST http://<remote-ip>:<remote-port>/api/generate \
   -H "Content-Type: application/json" \
-  -d '{"model": "llama3:8b-instruct", "prompt": "Hello, Ollama!"}'
+  -d '{"model": "llama3-chatqa:8b", "prompt": "Hello, Ollama!"}'
 ```
 
 

--- a/code/chatui/pages/converse.py
+++ b/code/chatui/pages/converse.py
@@ -276,7 +276,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                         ##### Use the Models tab to configure individual model components
                                         - All models are configured for self-hosted Ollama endpoints
                                         - Configure the IP/hostname and port for each component
-                                        - Default models: Router/Retrieval/Generator use phi4-reasoning:14b, Hallucination/Answer use llama3-chatqa:8b
+                                        - Default models: all components use llama3-chatqa:8b
                                         - (optional) Customize component behavior by changing the prompts
                                         """
                             )

--- a/code/chatui/utils/database.py
+++ b/code/chatui/utils/database.py
@@ -30,7 +30,7 @@ import shutil
 import mimetypes
 
 # Default model for local embeddings
-EMBEDDINGS_MODEL = 'llama3:8b-instruct'
+EMBEDDINGS_MODEL = 'llama3-chatqa:8b'
 # Base URL for the Ollama service. Defaults to the service name used in the
 # docker compose network.
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")

--- a/code/chatui/utils/graph.py
+++ b/code/chatui/utils/graph.py
@@ -190,7 +190,7 @@ def generate(state):
 
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_generator_ip"],
                                port=state["nim_generator_port"] if len(state["nim_generator_port"]) > 0 else "11434",
-                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "llama3:8b-instruct",
+                               model_name=state["nim_generator_id"] if len(state["nim_generator_id"]) > 0 else "llama3-chatqa:8b",
                                gpu_type=state.get("nim_generator_gpu_type"),
                                gpu_count=state.get("nim_generator_gpu_count"),
                                temperature=0.7)
@@ -226,7 +226,7 @@ def grade_documents(state):
 
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_retrieval_ip"],
                                port=state["nim_retrieval_port"] if len(state["nim_retrieval_port"]) > 0 else "11434",
-                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "llama3:8b-instruct",
+                               model_name=state["nim_retrieval_id"] if len(state["nim_retrieval_id"]) > 0 else "llama3-chatqa:8b",
                                gpu_type=state.get("nim_retrieval_gpu_type"),
                                gpu_count=state.get("nim_retrieval_gpu_count"),
                                temperature=0.0)
@@ -314,7 +314,7 @@ def route_question(state):
 
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_router_ip"],
                                port=state["nim_router_port"] if len(state["nim_router_port"]) > 0 else "11434",
-                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "llama3:8b-instruct",
+                               model_name=state["nim_router_id"] if len(state["nim_router_id"]) > 0 else "llama3-chatqa:8b",
                                gpu_type=state.get("nim_router_gpu_type"),
                                gpu_count=state.get("nim_router_gpu_count"),
                                temperature=0.0)
@@ -391,7 +391,7 @@ def grade_generation_v_documents_and_question(state):
 
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_hallucination_ip"],
                                port=state["nim_hallucination_port"] if len(state["nim_hallucination_port"]) > 0 else "11434",
-                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "llama3:8b-instruct",
+                               model_name=state["nim_hallucination_id"] if len(state["nim_hallucination_id"]) > 0 else "llama3-chatqa:8b",
                                gpu_type=state.get("nim_hallucination_gpu_type"),
                                gpu_count=state.get("nim_hallucination_gpu_count"),
                                temperature=0.0)
@@ -415,7 +415,7 @@ def grade_generation_v_documents_and_question(state):
 
     llm = nim.CustomChatOpenAI(custom_endpoint=state["nim_answer_ip"],
                                port=state["nim_answer_port"] if len(state["nim_answer_port"]) > 0 else "11434",
-                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "llama3:8b-instruct",
+                               model_name=state["nim_answer_id"] if len(state["nim_answer_id"]) > 0 else "llama3-chatqa:8b",
                                gpu_type=state.get("nim_answer_gpu_type"),
                                gpu_count=state.get("nim_answer_gpu_count"),
                                temperature=0.0)

--- a/code/chatui/utils/nim.py
+++ b/code/chatui/utils/nim.py
@@ -24,10 +24,10 @@ class CustomChatOpenAI(BaseChatModel):
 
     custom_endpoint: str = Field(None, description='Endpoint of self-hosted Ollama service')
     port: Optional[str] = "11434"
-    model_name: Optional[str] = "phi4-reasoning:14b"
+    model_name: Optional[str] = "llama3-chatqa:8b"
     temperature: Optional[float] = 0.0
 
-    def __init__(self, custom_endpoint, port="11434", model_name="phi4-reasoning:14b",
+    def __init__(self, custom_endpoint, port="11434", model_name="llama3-chatqa:8b",
                  temperature=0.0, **kwargs):
         super().__init__(**kwargs)
         self.custom_endpoint = custom_endpoint

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
         echo "All models pulled successfully!"
         wait
     environment:
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3:8b-instruct}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3-chatqa:8b}
     deploy:
       resources:
         reservations:

--- a/variables.env
+++ b/variables.env
@@ -8,12 +8,12 @@ TENSORBOARD_LOGS_DIRECTORY=/data/tensorboard/logs/
 OLLAMA_BASE_URL=http://ollama:11434
 
 # Default model pulled by the Ollama container at startup (used for embeddings)
-OLLAMA_MODEL=llama3:8b-instruct
+OLLAMA_MODEL=llama3-chatqa:8b
 
 # Default models for agentic RAG components (all self-hosted via Ollama)
-DEFAULT_ROUTER_MODEL=phi4-reasoning:14b
-DEFAULT_RETRIEVAL_MODEL=phi4-reasoning:14b
-DEFAULT_GENERATOR_MODEL=phi4-reasoning:14b
+DEFAULT_ROUTER_MODEL=llama3-chatqa:8b
+DEFAULT_RETRIEVAL_MODEL=llama3-chatqa:8b
+DEFAULT_GENERATOR_MODEL=llama3-chatqa:8b
 DEFAULT_HALLUCINATION_MODEL=llama3-chatqa:8b
 DEFAULT_ANSWER_MODEL=llama3-chatqa:8b
 


### PR DESCRIPTION
## Summary
- pull and run `llama3-chatqa:8b` by default
- default all agent models to `llama3-chatqa:8b`
- document default model in README and self-host instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827952a1e0832aa5fc7e1f7a29312d