### PR TITLE
Improve retrieval grading

### DIFF
--- a/code/chatui/pages/converse.py
+++ b/code/chatui/pages/converse.py
@@ -347,12 +347,17 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                     interactive=True
                                 )                                        
                                 
-                                with gr.Accordion("Configure the Retrieval Grader Prompt", 
+                                with gr.Accordion("Configure the Retrieval Grader Prompt",
                                                 elem_id="rag-inputs", open=False) as accordion_retrieval:
                                     prompt_retrieval = gr.Textbox(value=prompts_llama3.retrieval_prompt,
                                                                         lines=21,
                                                                         show_label=False,
                                                                         interactive=True)
+                                    prompt_relationship = gr.Textbox(value=prompts_llama3.relationship_prompt,
+                                                                      lines=21,
+                                                                      show_label=False,
+                                                                      interactive=True,
+                                                                      visible=False)
         
                             ###########################
                             ##### GENERATOR MODEL #####
@@ -775,6 +780,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                prompt_generator,
                                prompt_router,
                                prompt_retrieval,
+                               prompt_relationship,
                                prompt_hallucination,
                                prompt_answer,
                                nim_generator_ip,
@@ -800,6 +806,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                prompt_generator,
                                prompt_router,
                                prompt_retrieval,
+                               prompt_relationship,
                                prompt_hallucination,
                                prompt_answer,
                                nim_generator_ip,
@@ -825,6 +832,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                prompt_generator,
                                prompt_router,
                                prompt_retrieval,
+                               prompt_relationship,
                                prompt_hallucination,
                                prompt_answer,
                                nim_generator_ip,
@@ -850,6 +858,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                prompt_generator,
                                prompt_router,
                                prompt_retrieval,
+                               prompt_relationship,
                                prompt_hallucination,
                                prompt_answer,
                                nim_generator_ip,
@@ -875,6 +884,7 @@ def build_page(client: chat_client.ChatClient) -> gr.Blocks:
                                prompt_generator,
                                prompt_router,
                                prompt_retrieval,
+                               prompt_relationship,
                                prompt_hallucination,
                                prompt_answer,
                                nim_generator_ip,
@@ -931,6 +941,7 @@ def _stream_predict(
     prompt_generator: str,
     prompt_router: str,
     prompt_retrieval: str,
+    prompt_relationship: str,
     prompt_hallucination: str,
     prompt_answer: str,
     nim_generator_ip: str,
@@ -953,10 +964,11 @@ def _stream_predict(
 
     inputs = {"question": question, 
               "prompt_generator": prompt_generator, 
-              "prompt_router": prompt_router, 
-              "prompt_retrieval": prompt_retrieval, 
-              "prompt_hallucination": prompt_hallucination, 
-              "prompt_answer": prompt_answer, 
+              "prompt_router": prompt_router,
+              "prompt_retrieval": prompt_retrieval,
+              "prompt_relationship": prompt_relationship,
+              "prompt_hallucination": prompt_hallucination,
+              "prompt_answer": prompt_answer,
               "nim_generator_ip": nim_generator_ip,
               "nim_router_ip": nim_router_ip,
               "nim_retrieval_ip": nim_retrieval_ip,

--- a/code/chatui/prompts/prompts_llama3.py
+++ b/code/chatui/prompts/prompts_llama3.py
@@ -73,7 +73,7 @@ Here is the answer: {generation}
 """
 
 answer_prompt = """
-<|begin_of_text|><|start_header_id|>system<|end_header_id|> 
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
 You are a grader assessing whether an answer is useful to resolve a question. Give a binary score 'yes' or 'no' to indicate whether the answer is useful to resolve a question.
 
 Return ONLY valid JSON with no additional text or explanation.
@@ -83,6 +83,20 @@ Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": 
 Here is the answer:
 \n ------- \n {generation} \n ------- \n
 Here is the question: {question} 
+
+<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+"""
+
+relationship_prompt = """
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+You are a grader assessing whether a set of retrieved documents contain enough information to answer a user question. Evaluate the documents together and return a binary score 'yes' or 'no'.
+
+Return ONLY valid JSON with no additional text or explanation.
+Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}.
+
+<|eot_id|><|start_header_id|>user<|end_header_id|>
+Here are the retrieved documents:\n {documents} \n
+Here is the user question: {question}
 
 <|eot_id|><|start_header_id|>assistant<|end_header_id|>
 """

--- a/code/chatui/prompts/prompts_mistral.py
+++ b/code/chatui/prompts/prompts_mistral.py
@@ -60,7 +60,17 @@ Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": 
 
 Here is the answer:
 \n ------- \n {generation} \n ------- \n
-Here is the question: {question} 
+Here is the question: {question}
+
+[/INST]
+"""
+
+relationship_prompt = """
+<s>[INST] You are a grader assessing whether a collection of retrieved documents contains enough information to answer a user question. Evaluate the documents together and respond with a binary 'yes' or 'no'.
+Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+
+Here are the retrieved documents:\n {documents} \n
+Here is the user question: {question}
 
 [/INST]
 """


### PR DESCRIPTION
## Summary
- add relationship grading prompt for documents
- score document sets for retrieval relevance
- hide relationship grading prompt in UI
- plumb relationship prompt through stream handler

## Testing
- `python -m py_compile code/chatui/utils/graph.py code/chatui/pages/converse.py code/chatui/prompts/prompts_llama3.py code/chatui/prompts/prompts_mistral.py`
- `find code -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6882813a8448832abf332dfcab39735f