### PR TITLE
Fix relationship prompt template

### DIFF
--- a/code/chatui/prompts/prompts_llama3.py
+++ b/code/chatui/prompts/prompts_llama3.py
@@ -92,7 +92,7 @@ relationship_prompt = """
 You are a grader assessing whether a set of retrieved documents contain enough information to answer a user question. Evaluate the documents together and return a binary score 'yes' or 'no'.
 
 Return ONLY valid JSON with no additional text or explanation.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}.
 
 <|eot_id|><|start_header_id|>user<|end_header_id|>
 Here are the retrieved documents:\n {documents} \n

--- a/code/chatui/prompts/prompts_mistral.py
+++ b/code/chatui/prompts/prompts_mistral.py
@@ -67,7 +67,7 @@ Here is the question: {question}
 
 relationship_prompt = """
 <s>[INST] You are a grader assessing whether a collection of retrieved documents contains enough information to answer a user question. Evaluate the documents together and respond with a binary 'yes' or 'no'.
-Return only one of the following JSON objects: {"score": "yes"} or {"score": "no"}. Do not include any extra text.
+Return only one of the following JSON objects: {{"score": "yes"}} or {{"score": "no"}}. Do not include any extra text.
 
 Here are the retrieved documents:\n {documents} \n
 Here is the user question: {question}


### PR DESCRIPTION
## Summary
- fix malformed braces in `relationship_prompt` for both llama3 and mistral prompts

## Testing
- `python -m py_compile code/chatui/utils/graph.py code/chatui/prompts/prompts_llama3.py code/chatui/prompts/prompts_mistral.py`

------
https://chatgpt.com/codex/tasks/task_e_68839bfa3d88832aa05ae217324ffb25