### PR TITLE
Update Ollama container and docs

### DIFF
--- a/agentic-rag-docs/self-host.md
+++ b/agentic-rag-docs/self-host.md
@@ -35,6 +35,7 @@ This guide focuses on running a lightweight Ollama container.
  - Good for experimentation and development
  - See [Ollama Setup Guide](#ollama-setup) below
  - GPU requirements vary by model but can be as low as 8 GB of vRAM
+ - Version 0.10.0 or newer is recommended to enable advanced sampling options
 
 ## General Prerequisites
 
@@ -62,7 +63,7 @@ Do the following in the **remote** terminal. If you encounter any errors, use an
 ```bash
 # Pull the Ollama container. Change the tag if you want a different one. 
 
-docker pull ollama/ollama:latest
+docker pull ollama/ollama:0.10.0
 
 # Run it and make sure to connect the port on the remote, <remote-port>, to the Ollama port in the container, 11434
 
@@ -71,7 +72,7 @@ docker run -d --name ollama \
   -p <remote-port>:11434 \
   -v ollama_data:/root/.ollama \
   -e OLLAMA_MODEL=llama3-chatqa:8b \
-  ollama/ollama:latest
+  ollama/ollama:0.10.0
 
 # Make sure it is running properly
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.10.0
     runtime: nvidia
     entrypoint: ["/bin/bash", "-c"]
     command: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ tesseract==0.1.3
 nltk==3.8.1
 fastapi==0.111.0
 requests
-langchain-ollama==0.3.5
+langchain-ollama==0.3.6
 faiss-cpu>=1.7.4


### PR DESCRIPTION
## Summary
- bump `langchain-ollama` to v0.3.6
- pin Ollama container version 0.10.0
- update self-host guide accordingly with note on version requirements

## Testing
- `python -m compileall -q code`
- `pip install -r requirements.txt`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_688a8d9ab6f4832a8e433f16929c1c6f